### PR TITLE
Support for Android

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4161,7 +4161,8 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-machine-uid"
 version = "0.1.0"
-source = "git+ssh://git@github.com/SkipperNDT/tauri-plugin-machine-uid.git?branch=main#6f7d9073817aaf966e9401d65b8d316fb33ad84a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e3b3e4131abb59823f83a3e8d9fc6f94f8194476de2170ec1dfded1b1e1e0e"
 dependencies = [
  "machine-uid",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1970,7 +1976,6 @@ dependencies = [
  "hostname",
  "lazy_static",
  "log",
- "machine-uid",
  "mockito",
  "num_cpus",
  "rand 0.7.3",
@@ -2334,7 +2339,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -2721,6 +2726,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -3752,6 +3763,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "specta"
+version = "2.0.0-rc.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7f01e9310a820edd31c80fde3cae445295adde21a3f9416517d7d65015b971"
+dependencies = [
+ "paste",
+ "specta-macros",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "specta-macros"
+version = "2.0.0-rc.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0074b9e30ed84c6924eb63ad8d2fe71cdc82628525d84b1fcb1f2fd40676517"
+dependencies = [
+ "Inflector",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "specta-serde"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77216504061374659e7245eac53d30c7b3e5fe64b88da97c753e7184b0781e63"
+dependencies = [
+ "specta",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "specta-typescript"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3220a0c365e51e248ac98eab5a6a32f544ff6f961906f09d3ee10903a4f52b2d"
+dependencies = [
+ "specta",
+ "specta-serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3985,6 +4040,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serialize-to-javascript",
+ "specta",
  "swift-rs",
  "tauri-build",
  "tauri-macros",
@@ -4095,10 +4151,25 @@ dependencies = [
  "sys-locale",
  "tauri",
  "tauri-plugin",
+ "tauri-plugin-machine-uid",
  "tauri-plugin-os",
  "thiserror 1.0.69",
  "tokio",
  "whoami",
+]
+
+[[package]]
+name = "tauri-plugin-machine-uid"
+version = "0.1.0"
+source = "git+ssh://git@github.com/SkipperNDT/tauri-plugin-machine-uid.git?branch=main#6f7d9073817aaf966e9401d65b8d316fb33ad84a"
+dependencies = [
+ "machine-uid",
+ "serde",
+ "specta",
+ "tauri",
+ "tauri-plugin",
+ "tauri-specta",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -4163,6 +4234,21 @@ dependencies = [
  "webview2-com 0.36.0",
  "windows 0.60.0",
  "wry",
+]
+
+[[package]]
+name = "tauri-specta"
+version = "2.0.0-rc.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b23c0132dd3cf6064e5cd919b82b3f47780e9280e7b5910babfe139829b76655"
+dependencies = [
+ "heck 0.5.0",
+ "serde",
+ "serde_json",
+ "specta",
+ "specta-typescript",
+ "tauri",
+ "thiserror 2.0.12",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ rand = "0.7.3"
 hostname = "0.4.0"
 num_cpus = "1.16.0"
 dotenv = "0.15.0"
-machine-uid = "0.5.1"
 aes-gcm = "0.9"
 log = { version = "0.4", features = ["std"] }
 futures-timer = "3.0.3"

--- a/packages/tauri-plugin-keygen-rs2/Cargo.toml
+++ b/packages/tauri-plugin-keygen-rs2/Cargo.toml
@@ -21,8 +21,10 @@ lazy_static = "1.4.0"
 log = { version = "0.4", features = ["std"] }
 sys-locale = "0.3"
 keygen-rs = "0.4.2"
-tauri-plugin-machine-uid = { git = "ssh://git@github.com/SkipperNDT/tauri-plugin-machine-uid.git", branch = "main" }
 # keygen-rs = { path = "../.." }
+
+[target."cfg(not(any(target_os = \"macos\", windows, target_os = \"linux\")))".dependencies]
+tauri-plugin-machine-uid = "0.1.0"
 
 [target."cfg(any(target_os = \"macos\", windows, target_os = \"linux\"))".dependencies]
 machine-uid = { version = "0.5.3" }

--- a/packages/tauri-plugin-keygen-rs2/Cargo.toml
+++ b/packages/tauri-plugin-keygen-rs2/Cargo.toml
@@ -16,13 +16,16 @@ serde = "1.0"
 serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.33.0", features = ["sync"] }
-machine-uid = "0.5.1"
 whoami = "1.5.1"
 lazy_static = "1.4.0"
 log = { version = "0.4", features = ["std"] }
 sys-locale = "0.3"
 keygen-rs = "0.4.2"
+tauri-plugin-machine-uid = { git = "ssh://git@github.com/SkipperNDT/tauri-plugin-machine-uid.git", branch = "main" }
 # keygen-rs = { path = "../.." }
+
+[target."cfg(any(target_os = \"macos\", windows, target_os = \"linux\"))".dependencies]
+machine-uid = { version = "0.5.3" }
 
 [build-dependencies]
 tauri-plugin = { version = "2.0.1", features = ["build"] }

--- a/packages/tauri-plugin-keygen-rs2/build.rs
+++ b/packages/tauri-plugin-keygen-rs2/build.rs
@@ -1,8 +1,5 @@
 const COMMANDS: &[&str] = &["ping"];
 
 fn main() {
-  tauri_plugin::Builder::new(COMMANDS)
-    .android_path("android")
-    .ios_path("ios")
-    .build();
+    tauri_plugin::Builder::new(COMMANDS).build();
 }

--- a/packages/tauri-plugin-keygen-rs2/src/lib.rs
+++ b/packages/tauri-plugin-keygen-rs2/src/lib.rs
@@ -140,7 +140,7 @@ impl Builder {
                 let app_name = app_handle.package_info().name.clone();
                 let app_version = app_handle.package_info().version.to_string();
 
-                let machine_state = MachineState::new(app_name, app_version);
+                let machine_state = MachineState::new(app_handle, app_name, app_version);
                 app_handle.manage(Mutex::new(machine_state));
 
                 let license_state = LicenseState::load(app_handle);

--- a/packages/tauri-plugin-keygen-rs2/src/license.rs
+++ b/packages/tauri-plugin-keygen-rs2/src/license.rs
@@ -129,7 +129,7 @@ impl LicenseState {
                 });
             }
             // attempt to load the machine file
-            let fingerprint = MachineState::get_fingerprint();
+            let fingerprint = MachineState::get_fingerprint_app(app_handle);
             let key = format!("{}{}", &license_key, fingerprint);
             if let Some(machine_file) = MachineState::load_machine_file(app_handle, &key)? {
                 let dataset = machine_file.decrypt(&key)?;

--- a/packages/tauri-plugin-keygen-rs2/src/machine.rs
+++ b/packages/tauri-plugin-keygen-rs2/src/machine.rs
@@ -6,6 +6,7 @@ use std::{
 
 use keygen_rs::{machine::MachineCheckoutOpts, machine_file::MachineFile};
 use tauri::{webview_version, AppHandle, Runtime};
+#[cfg(mobile)]
 use tauri_plugin_machine_uid::MachineUidExt;
 
 use crate::{error::Error, utils::get_app_keygen_path, AppHandleExt, Result};
@@ -36,15 +37,25 @@ impl MachineState {
         machine_uid::get().unwrap_or_default()
     }
 
-    #[cfg(mobile)]
-    pub fn get_fingerprint() -> String {
-        "mobile".to_string()
+    #[cfg(desktop)]
+    pub fn get_fingerprint_app<R: Runtime>(_app_handle: &AppHandle<R>) -> String {
+        Self::get_fingerprint()
     }
 
+    #[cfg(mobile)]
+    pub fn get_fingerprint() -> String {
+        panic!(
+            r#"On mobile, you should use the `get_fingerprint_app` method instead of `get_fingerprint`."#
+        );
+    }
+
+    #[cfg(mobile)]
     pub fn get_fingerprint_app<R: Runtime>(app_handle: &AppHandle<R>) -> String {
         let Some(state) = app_handle.try_machine_uid() else {
-            log::warn!("tauri-plugin-machine-uid is not initialized. You should add it to your application and initialize it before tauri-plugin-keygen-rs2. Using default fingerprint.");
-            return Self::get_fingerprint();
+            panic!(
+                r#"tauri-plugin-machine-uid is not initialized but is required to get machine fingerprints on mobile. 
+You should add it to your application and initialize it before tauri-plugin-keygen-rs2."#
+            );
         };
 
         state


### PR DESCRIPTION
I updated some small parts both in keygen-rs and tauri-plugin-keygen-rs2 to make it work with Android:

- I switched reqwest to the rustls feature which bypasses openssl (that is not easily available on Android)
- I updated the build script for tauri-plugin-keygen-rs2 which was failling to build because it's not setup properly
- I disabled machine_uid on the Android target, which make the "get_fingerprint" function return an empty string on Android, and the same value as before on other os.

I have developped a private tauri plugin to retrieve the machine id that wraps around machine_uid on desktop but uses some small kotlin code for Android (and I will add the required swift code for iOS). I may make it public in the coming months, so you might be able to use the plugin instead of directly calling machine_uid.