### PR TITLE
Feat/ping and heartbeat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ dotenv = "0.15.0"
 machine-uid = "0.5.1"
 aes-gcm = "0.9"
 log = { version = "0.4", features = ["std"] }
+futures-timer = "3.0.3"
 
 [lib]
 doctest = false

--- a/examples/start_heartbeat.rs
+++ b/examples/start_heartbeat.rs
@@ -1,0 +1,45 @@
+use std::{
+    sync::{mpsc, Arc},
+    thread,
+    time::Duration,
+};
+
+use keygen_rs::{
+    config::{self, KeygenConfig},
+    errors::Error,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    config::set_config(KeygenConfig {
+        api_url: env::var("KEYGEN_API_URL").expect("KEYGEN_API_URL must be set"),
+        account: env::var("KEYGEN_ACCOUNT").expect("KEYGEN_ACCOUNT must be set"),
+        product: env::var("KEYGEN_PRODUCT").expect("KEYGEN_PRODUCT must be set"),
+        license_key: Some(env::var("KEYGEN_LICENSE_KEY").expect("KEYGEN_LICENSE_KEY must be set")),
+        public_key: Some(env::var("KEYGEN_PUBLIC_KEY").expect("KEYGEN_PUBLIC_KEY must be set")),
+        ..KeygenConfig::default()
+    });
+    let fingerprint = machine_uid::get().unwrap_or("".into());
+    if let Ok(license) = keygen_rs::validate(&[fingerprint.clone()], &[]).await {
+        let machine = license.machine(&fingerprint).await?;
+        let interval = Duration::from_secs(machine.heartbeat_duration.unwrap_or(570) as u64);
+
+        let machine_arc = Arc::new(machine);
+
+        let (tx, rx) = mpsc::channel();
+
+        let monitor_future = machine_arc.clone().monitor(interval, Some(tx));
+
+        tokio::spawn(async move {
+            monitor_future.await;
+        });
+
+        loop {
+            // Keep this thread alive and monitor for received errors
+            thread::sleep(Duration::from_secs(10));
+            println!("{}", rx.recv().unwrap());
+        }
+    }
+
+    Ok(())
+}

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::certificate::CartificateFileResponse;
-use crate::client::Client;
+use crate::client::{Client, Response};
 use crate::errors::Error;
 use crate::machine_file::MachineFile;
 use crate::KeygenResponseData;
@@ -110,4 +110,17 @@ impl Machine {
         let machine_file = MachineFile::from(machine_file_response.data);
         Ok(machine_file)
     }
+
+    pub async fn ping(&self) -> Result<(), Error> {
+        let client = Client::default();
+        let _response: Response<MachineResponse> = client
+            .post(&format!(
+                "machines/{}/actions/ping", self.id),
+                None::<&()>,
+                None::<&()>
+            )
+            .await?;
+        Ok(())
+    }
+
 }


### PR DESCRIPTION
See issue: #7  
Added a ping and a monitor method to Machine as well as a new example.
Tried to keep it as similar to the keygen-go implementation, except for:

- it does not panic on a failed heartbeat, but  transmits the error through an async channel to be handled by the caller for more flexibility. 
- also it does not read the interval from the Machine struct, because it can be None, the caller can decide on a good default. 

Also I added the futures-timer crate as a dependency so that there is an async-runtime agnostic delay.